### PR TITLE
Hotfix 1.0.4

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,8 +1,8 @@
 {
     "name":"PresideCMS Extension: Sentry error reporting",
     "type":"preside-extensions",
-    "version":"1.0.3",
-    "location":"https://github.com/pixl8/preside-ext-sentry/archive/v1.0.3.zip",
+    "version":"1.0.4",
+    "location":"https://github.com/pixl8/preside-ext-sentry/archive/v1.0.4.zip",
     "author":"Pixl8 Interactive",
     "directory":"application/extensions",
     "homepage":"https://github.com/pixl8/preside-ext-sentry",

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,6 @@
 	  "id"        : "preside-ext-sentry"
 	, "title"     : "Pixl8 Sentry Extension for Preside"
 	, "author"    : "Pixl8 Interactive"
-	, "version"   : "1.0.3"
+	, "version"   : "1.0.4"
 	, "changelog" : ""
 }

--- a/services/errors/ErrorHandler.cfc
+++ b/services/errors/ErrorHandler.cfc
@@ -1,6 +1,6 @@
-component output=false {
+component {
 
-	public void function raiseError( required struct error ) output=false {
+	public void function raiseError( required struct error ) {
 		var sentryClient = _getSentryClient();
 
 		if ( !IsNull( sentryClient ) ) {
@@ -9,15 +9,15 @@ component output=false {
 	}
 
 // private
-	private any function _getSentryClient() output=false {
+	private any function _getSentryClient() {
 		var apiKey = _getApiKey();
 
 		if ( Len( Trim( apiKey ) ) ) {
-			return new SentryClient( _getApiKey() );
+			return new SentryClient( apiKey );
 		}
 	}
 
-	private string function _getApiKey() output=false {
+	private string function _getApiKey() {
 		return application.SENTRY_API_KEY ?: ( application.injectedConfig.SENTRY_API_KEY ?: "" );
 	}
 

--- a/services/errors/SentryClient.cfc
+++ b/services/errors/SentryClient.cfc
@@ -1,7 +1,7 @@
-component output=false {
+component {
 
 // CONSTRUCTOR
-	public any function init( required string apiKey, string sentryProtocolVersion="2.0" ) output=false {
+	public any function init( required string apiKey, string sentryProtocolVersion="2.0" ) {
 		_setCredentials( arguments.apiKey );
 		_setProtocolVersion( arguments.sentryProtocolVersion );
 
@@ -9,7 +9,7 @@ component output=false {
 	}
 
 // PUBLIC API METHODS
-	public void function captureException( required struct exception, struct tags={}, struct extraInfo={} ) output=false {
+	public void function captureException( required struct exception, struct tags={}, struct extraInfo={} ) {
 		var e           = arguments.exception;
 		var errorType   = ( e.type ?: "Unknown type" ) & " error";
 		var message     = e.message ?: "";
@@ -36,7 +36,7 @@ component output=false {
 
 
 // PRIVATE HELPERS
-	private void function _setCredentials( required string apiKey ) output=false {
+	private void function _setCredentials( required string apiKey ) {
 		var regex = "^(https?://)((.*?):(.*?)@)(.*?)/([1-9][0-9]*)$";
 
 		_setEndpoint( ReReplaceNoCase( arguments.apiKey, regex, "\1\5" ) & "/api/store/" );
@@ -45,7 +45,7 @@ component output=false {
 		_setProjectId( ReReplaceNoCase( arguments.apiKey, regex, "\6" ) );
 	}
 
-	private array function _convertTagContext( required array tagContext ) output=false {
+	private array function _convertTagContext( required array tagContext ) {
 		var frames = [];
 
 		for( var tc in arguments.tagContext ) {
@@ -76,7 +76,7 @@ component output=false {
 		return frames;
 	}
 
-	private void function _apiCall( required struct packet ) output=false {
+	private void function _apiCall( required struct packet ) {
 		var timeVars        = _getTimeVars();
 
 		packet.event_id    = LCase( Replace( CreateUUId(), "-", "", "all" ) );
@@ -96,7 +96,7 @@ component output=false {
 		}
 	}
 
-	private struct function _getHttpRequest() output=false {
+	private struct function _getHttpRequest() {
 		var httpRequestData = getHTTPRequestData();
 		var rq = {
 			  data         = FORM
@@ -127,7 +127,7 @@ component output=false {
 		return rq;
 	}
 
-	private struct function _getTimeVars() output=false {
+	private struct function _getTimeVars() {
 		var timeVars = {};
 
 		timeVars.utcNowTime = DateConvert( "Local2utc", Now() );
@@ -137,7 +137,7 @@ component output=false {
 		return timeVars;
 	}
 
-	private string function _generateSignature( required string time, required string json ) output=false {
+	private string function _generateSignature( required string time, required string json ) {
 		var messageToSign = ListAppend( arguments.time, arguments.json, " " );
 		var jMsg = JavaCast( "string", messageToSign ).getBytes( "iso-8859-1" );
 		var jKey = JavaCast( "string", _getPrivateKey() ).getBytes( "iso-8859-1" );
@@ -151,38 +151,38 @@ component output=false {
 	}
 
 // GETTERS AND SETTERS
-	private string function _getEndpoint() output=false {
+	private string function _getEndpoint() {
 		return _endpoint;
 	}
-	private void function _setEndpoint( required string endpoint ) output=false {
+	private void function _setEndpoint( required string endpoint ) {
 		_endpoint = arguments.endpoint;
 	}
 
-	private string function _getPublicKey() output=false {
+	private string function _getPublicKey() {
 		return _publicKey;
 	}
-	private void function _setPublicKey( required string publicKey ) output=false {
+	private void function _setPublicKey( required string publicKey ) {
 		_publicKey = arguments.publicKey;
 	}
 
-	private string function _getPrivateKey() output=false {
+	private string function _getPrivateKey() {
 		return _privateKey;
 	}
-	private void function _setPrivateKey( required string privateKey ) output=false {
+	private void function _setPrivateKey( required string privateKey ) {
 		_privateKey = arguments.privateKey;
 	}
 
-	private string function _getProjectId() output=false {
+	private string function _getProjectId() {
 		return _projectId;
 	}
-	private void function _setProjectId( required string projectId ) output=false {
+	private void function _setProjectId( required string projectId ) {
 		_projectId = arguments.projectId;
 	}
 
-	private any function _getProtocolVersion() output=false {
+	private any function _getProtocolVersion() {
 		return _protocolVersion;
 	}
-	private void function _setProtocolVersion( required any protocolVersion ) output=false {
+	private void function _setProtocolVersion( required any protocolVersion ) {
 		_protocolVersion = arguments.protocolVersion;
 	}
 }


### PR DESCRIPTION
Updated the method _getSentryClient() to use the local apiKey variable rather than call the _getApiKey(0 method twice.